### PR TITLE
Change used Quick Start data to fix unit test

### DIFF
--- a/frontend/packages/console-app/src/components/quick-starts/controller/__tests__/QuickStartTasks.spec.tsx
+++ b/frontend/packages/console-app/src/components/quick-starts/controller/__tests__/QuickStartTasks.spec.tsx
@@ -10,7 +10,7 @@ import QuickStartTaskReview from '../QuickStartTaskReview';
 type QuickStartTaskProps = React.ComponentProps<typeof QuickStartTask>;
 let wrapper: ShallowWrapper<QuickStartTaskProps>;
 const props: QuickStartTaskProps = {
-  tasks: getQuickStartByName('explore-pipelines').spec.tasks,
+  tasks: getQuickStartByName('monitor-sampleapp').spec.tasks,
   allTaskStatuses: [
     QuickStartTaskStatus.SUCCESS,
     QuickStartTaskStatus.INIT,
@@ -48,7 +48,7 @@ describe('QuickStartTasks', () => {
         .find(SyncMarkdownView)
         .at(0)
         .props().content,
-    ).toEqual(props.tasks[1].recapitulation.success);
+    ).toEqual(props.tasks[0].recapitulation.success);
 
     expect(
       wrapper


### PR DESCRIPTION
As written here https://github.com/openshift/console/pull/6307#issuecomment-683732011 this changes are required to make our unit tests green again.